### PR TITLE
feature: Add a slew of typographic wonders

### DIFF
--- a/styles/base/extenders/_b.ex.typography.scss
+++ b/styles/base/extenders/_b.ex.typography.scss
@@ -37,6 +37,28 @@
 // SMALL PRINT
 // -------------------------------------
 
+/// Super tiny text
+/// ---
+/// @param {bool} $extend (true)
+///   Extend placeholder in the current breakpoint if true, 
+///   include rules if false.
+/// ---
+/// @group Typography
+/// ---
+@mixin t-nano($extend: true){
+  @if $extend {
+    @include ex-cur-bp(t-nano){
+      @include t-nano($extend: false);
+    }
+  }
+  @else {
+    @include font-size(fs(nano));
+    @if setting(type, nano-style) {
+      font-family: family(small);
+    }
+  }
+}
+
 /// Tiny text
 /// ---
 /// @param {bool} $extend (true)
@@ -100,7 +122,6 @@
 /// ---
 @mixin t-headlines($extend: true) {
   @if $extend {
-    // @debug &;
     @include ex-cur-bp(t-headlines) {
       @include t-headlines($extend: false);
     }
@@ -385,6 +406,9 @@
     @include bp($bp) {
       %typography-placeholder-private-#{$bp} {
         @include t-base;
+        @if setting(type, map, nano) {
+          @include t-nano;
+        }
         @include t-micro;
         @include t-milli;
         @include t-zeta;

--- a/styles/base/extenders/_b.ex.typography.scss
+++ b/styles/base/extenders/_b.ex.typography.scss
@@ -366,8 +366,7 @@
     &:hover, 
     &:focus,
     &:active {
-      border-bottom: 1px solid;
-      padding-bottom: .06em;
+      text-decoration: underline;
     }
   }
 }

--- a/styles/base/extenders/_b.ex.typography.scss
+++ b/styles/base/extenders/_b.ex.typography.scss
@@ -23,7 +23,7 @@
 /// ---
 /// @group Typography
 /// ---
-@mixin t-base($extend: true){
+@mixin t-base($extend: false){
   @if $extend {
     @include ex-cur-bp(t-base){
       @include t-base($extend: false);
@@ -410,7 +410,7 @@
   @each $bp, $value in $bp-breakpoints {
     @include bp($bp) {
       %typography-placeholder-private-#{$bp} {
-        @include t-base;
+        // @include t-base;
         @if setting(type, map, nano) {
           @include t-nano;
         }

--- a/styles/base/extenders/_b.ex.typography.scss
+++ b/styles/base/extenders/_b.ex.typography.scss
@@ -127,9 +127,15 @@
     }
   }
   @else {
-    // 1. Better font rendering in Chrome and on osX
-    font-weight: 700;
-    text-rendering: optimizeLegibility;
+    // 1. Set the font weight of headlines according
+    //    the project's settings, with a default of
+    //    700 if none is defined.
+    // 2. Better font rendering in Chrome and on osX
+    font-weight: if(                        // [1]
+                    map-has-key(map-get($settings, type), headline-weight), 
+                      setting(type, headline-weight), 
+                      700);
+    text-rendering: optimizeLegibility;     // [2]
     @if setting(type, headline-style) {
       font-family: family(headlines);
       font-feature-settings: "calt", "liga";

--- a/styles/utils/_u.units.scss
+++ b/styles/utils/_u.units.scss
@@ -3,7 +3,6 @@
 // #UNITS
 //
 // -> Unit conversion utils from Compass
-//    system with PX fallback
 //
 //    Extracted from Compass to remove the dependency
 ////


### PR DESCRIPTION
- fix t-base cascade issues
- underline text-links using `text-decoration`
- Add ability to set headlines' `font-weight`
- Add `t-nano` dry mixin to generate extra tiny text. Small type can
  optionally have its own font-family.
- integrate t-nano into typo-placeholder
