### PR TITLE
fix(nav--separated): remove `:after` of last-child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.1
+- **Fix:** Don't render pseudo element of last list item in `.nav--separated`
+
 ## 2.1.0
 - **New:** Add `.vid-wrapper--flush` modifier, that removes the default 
   margin bottom of `.vid-wrapper`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htz-sassbp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The Sass boilerplate for the Haaretz Group websites",
   "repository": {
     "type": "git",

--- a/styles/objects/_o.nav.scss
+++ b/styles/objects/_o.nav.scss
@@ -47,7 +47,7 @@
          content: "\002c" "\00a0";
        }
        &:last-child:after {
-         content: "";
+         content: none;
        }
      }
   }


### PR DESCRIPTION
- Remove the `:after` pseudo element of the last li instead of setting
  is to `""`. This way it is not rendered and does not has padding.
