### PR TITLE
fix(nav--separated): remove `:after` of last-child

### DIFF
--- a/styles/objects/extenders/_o.ex.lists.scss
+++ b/styles/objects/extenders/_o.ex.lists.scss
@@ -127,7 +127,7 @@
       content: quote(setting(inline-list, separator-char));
     }
     > li:last-child:after {
-      content: "";
+      content: none;
     }
   }
 }


### PR DESCRIPTION
One of two changes was omitted in last commit
